### PR TITLE
Fixed the following Error when BBBEnvironmentType is set as 'single'

### DIFF
--- a/templates/bbb-on-aws-securitygroups.template.yaml
+++ b/templates/bbb-on-aws-securitygroups.template.yaml
@@ -88,6 +88,7 @@ Resources:
 
   BBBECSSecurityGroupPublicHTTP:
     Type: AWS::EC2::SecurityGroupIngress
+    Condition: BBBScalableEnvironment
     Properties:
       CidrIp: 0.0.0.0/0
       IpProtocol: tcp


### PR DESCRIPTION
'Condition: BBBScalableEnvironment ' should be added after line 90. 
Error Caused: CREATE_FAILED  Template format error: Unresolved resource dependencies [BBBFrontendELBSecurityGroup] in the Resources block of the template. 
Above error is caused while deploying 'Single Server deployments' and can be solved by adding the condition line after line 90.